### PR TITLE
Float32 operators overloading to avoid generate `double`

### DIFF
--- a/std/cxx/num/Float32.hx
+++ b/std/cxx/num/Float32.hx
@@ -6,4 +6,49 @@ package cxx.num;
 @:coreType
 @:notNull
 @:runtimeValue
-extern abstract Float32 to Float from Float {}
+extern abstract Float32 to Float from Float {
+
+    @:op(-A)
+    private static function neg(a: Float32) : Float32;
+
+    @:op(--A)
+    private static function predec(a: Float32) : Float32;
+
+    @:op(++A)
+    private static function preinc(a: Float32) : Float32;
+
+    @:op(A--)
+    private static function dec(a: Float32) : Float32;
+
+    @:op(A++)
+    private static function inc(a: Float32) : Float32;
+    
+    @:op(A + B)
+    private static function add(a: Float32, b: Float32) : Float32;
+    
+    @:op(A - B)
+    private static function sub(a: Float32, b: Float32) : Float32;
+    
+    @:op(A * B)
+    private static function mul(a: Float32, b: Float32) : Float32;
+
+    @:op(A / B)
+    private static function div(a: Float32, b: Float32) : Float32;
+
+    // C/C++ does not support modulo on float
+    // @:op(A % B)
+    // @:native("fmodf") -- maybe this
+    // private static function mod(a: Float32, b: Float32) : Float32;
+
+    // haxe.Float does not support bitwise on float, but C/C++ does
+    // @:op(A | B)
+    // private static function or(a: Float32, b: Float32) : Float32;
+
+    // haxe.Float does not support bitwise on float, but C/C++ does
+    // @:op(A & B)
+    // private static function and(a: Float32, b: Float32) : Float32;
+
+    // haxe.Float does not support bitwise on float, but C/C++ does
+    // @:op(A ^ B)
+    // private static function xor(a: Float32, b: Float32) : Float32;
+}

--- a/test/unit_testing/tests/FloatTypes/.gitignore
+++ b/test/unit_testing/tests/FloatTypes/.gitignore
@@ -1,0 +1,2 @@
+build
+out

--- a/test/unit_testing/tests/FloatTypes/Main.hx
+++ b/test/unit_testing/tests/FloatTypes/Main.hx
@@ -1,0 +1,54 @@
+package;
+
+import cxx.num.Float32;
+
+var returnCode = 0;
+function assertIsFloat32<T: cxx.num.Float32>(v: T) {
+	if(untyped __cpp__("sizeof({0}) != 4", v)) {
+		returnCode = 1;
+	}
+}
+
+function getZ() : Float32 {
+    return 3.0;
+}
+
+function main() {
+    final x = cast(1.0, Float32);
+    assertIsFloat32(x);
+
+    final y: Float32 = 2.0;
+    assertIsFloat32(y);
+
+    final z = getZ();
+    assertIsFloat32(z);
+
+    final w = x + y + z;
+    assertIsFloat32(w);
+
+    final a = w - 2;
+    assertIsFloat32(a);
+
+    final b = a * 2;
+    assertIsFloat32(b);
+
+    var c = b / 2;
+    assertIsFloat32(c);
+
+    var d = --c;
+    assertIsFloat32(d);
+
+    var e = ++d;
+    assertIsFloat32(e);
+
+    var f = e--;
+    assertIsFloat32(f);
+
+    final g = f++;
+    assertIsFloat32(g);
+
+    final h = -g;
+    assertIsFloat32(h);
+
+	Sys.exit(returnCode);
+}

--- a/test/unit_testing/tests/FloatTypes/Test.hxml
+++ b/test/unit_testing/tests/FloatTypes/Test.hxml
@@ -1,0 +1,6 @@
+# The following are added automatically:
+# -lib reflaxe.cpp
+# -D cpp-output=out
+
+-D mainClass=Main
+-main Main

--- a/test/unit_testing/tests/FloatTypes/intended/_GeneratedFiles.txt
+++ b/test/unit_testing/tests/FloatTypes/intended/_GeneratedFiles.txt
@@ -1,0 +1,3 @@
+src/_main_.cpp
+src/Main.cpp
+include/Main.h

--- a/test/unit_testing/tests/FloatTypes/intended/include/Main.h
+++ b/test/unit_testing/tests/FloatTypes/intended/include/Main.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace _Main {
+
+class Main_Fields_ {
+public:
+	static int returnCode;
+
+	template<typename T>
+	static void assertIsFloat32(T v) {
+		if(sizeof(v) != 4) {
+			_Main::Main_Fields_::returnCode = 1;
+		};
+	}
+	static float getZ();
+	static void main();
+};
+
+}

--- a/test/unit_testing/tests/FloatTypes/intended/src/Main.cpp
+++ b/test/unit_testing/tests/FloatTypes/intended/src/Main.cpp
@@ -1,0 +1,60 @@
+#include "Main.h"
+
+#include <cstdlib>
+
+int _Main::Main_Fields_::returnCode = 0;
+
+float _Main::Main_Fields_::getZ() {
+	return (float)(3.0f);
+}
+
+void _Main::Main_Fields_::main() {
+	float x = ((float)(1.0));
+
+	_Main::Main_Fields_::assertIsFloat32<float>(x);
+
+	float y = (float)(2.0f);
+
+	_Main::Main_Fields_::assertIsFloat32<float>(y);
+
+	float z = _Main::Main_Fields_::getZ();
+
+	_Main::Main_Fields_::assertIsFloat32<float>(z);
+
+	float w = x + y + z;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(w);
+
+	float a = w - 2;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(a);
+
+	float b = a * 2;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(b);
+
+	float c = b / 2;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(c);
+
+	float d = --c;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(d);
+
+	float e = ++d;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(e);
+
+	float f = e--;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(f);
+
+	float g = f++;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(g);
+
+	float h = -g;
+
+	_Main::Main_Fields_::assertIsFloat32<float>(h);
+	exit(_Main::Main_Fields_::returnCode);
+}

--- a/test/unit_testing/tests/FloatTypes/intended/src/_main_.cpp
+++ b/test/unit_testing/tests/FloatTypes/intended/src/_main_.cpp
@@ -1,0 +1,7 @@
+#include <memory>
+#include "Main.h"
+
+int main(int, const char**) {
+	_Main::Main_Fields_::main();
+	return 0;
+}


### PR DESCRIPTION
Haxe:
![image](https://github.com/RobertBorghese/reflaxe.CPP/assets/7189568/587c6de4-680d-4d1f-88d0-64934812bfa0)

Generated C++:
![image](https://github.com/RobertBorghese/reflaxe.CPP/assets/7189568/5c80bd9e-fc9a-49a3-b848-f22b7bf20558)

After add operators overloading:
![image](https://github.com/RobertBorghese/reflaxe.CPP/assets/7189568/d20aa9b9-917d-486a-8be7-6a7e91baa2ed)
