### PR TITLE
Added `exists` to FileSystem

### DIFF
--- a/src/cxx/std/FileSystem.hx
+++ b/src/cxx/std/FileSystem.hx
@@ -17,6 +17,14 @@ extern class FileSystem {
 	@:native("std::filesystem::current_path")
 	@:include("filesystem", true)
 	public static overload extern function currentPath(newPath: String): Path;
+
+	@:native("std::filesystem::exists")
+	@:include("filesystem", true)
+	public static overload extern function exists(newPath: Path): Bool;
+
+	@:native("std::filesystem::exists")
+	@:include("filesystem", true)
+	public static overload extern function exists(newPath: String): Bool;
 }
 
 @:native("std::filesystem::path")


### PR DESCRIPTION
Path.hx:
```haxe
static private function getPath(file:String, library:Null<String>):String {
		if(library != null) return getLibraryPathForce(file, library);

		if(currentLevel != null) {
				var levelPath:String = getLibraryPathForce(file, currentLevel);
				if(FileSystem.exists(levelPath)) return levelPath;
		}

		var levelPath:String = getLibraryPathForce(file, "shared");
		if(FileSystem.exists(levelPath)) return levelPath;

		return file;
}
```

To Path.cpp:
```cpp
std::string Path::getPath(std::string file, std::optional<std::string> library) {
	if(library.has_value()) {
		return Path::getLibraryPathForce(file, library.value());
	};

	{
		std::string levelPath = Path::getLibraryPathForce(file, Path::currentLevel);

		if(std::filesystem::exists(levelPath)) {
			return levelPath;
		};
	};

	std::string levelPath = Path::getLibraryPathForce(file, "shared"s);

	if(std::filesystem::exists(levelPath)) {
		return levelPath;
	};

	return file;
}
```


