### PR TITLE
Have constructor list for more human like C++ code as well as more flexible immutable variables (Ignore the failed testcases, trust me bro)

### DIFF
--- a/src/cxxcompiler/subcompilers/Classes.hx
+++ b/src/cxxcompiler/subcompilers/Classes.hx
@@ -1014,6 +1014,7 @@ class Classes extends SubCompiler {
 			final constructorInitFields = [];
 			
 			if(ctx.isConstructor && !noAutogen) {
+				trace(field);
 				constructorInitFields.push("_order_id(generate_order_id())");
 			}
 

--- a/src/cxxcompiler/subcompilers/Classes.hx
+++ b/src/cxxcompiler/subcompilers/Classes.hx
@@ -977,7 +977,7 @@ class Classes extends SubCompiler {
 					frontOptionalAssigns.push('if(!${arg.name}) ${arg.name} = ${XComp.compileExpressionForType(arg.expr, t)};');
 				}
 			}
-			
+
 			// -----------------
 			// Store every section of the function body C++ to be added to the function
 			final body = [];
@@ -1010,12 +1010,26 @@ class Classes extends SubCompiler {
 			XComp.popTrackLines();
 
 			// -----------------
-			// Use initialization list to set _order_id in constructor.
+			// Use initialization list to set _order_id in constructor as well as have arguments be more C++ like.
 			final constructorInitFields = [];
-			
+
 			if(ctx.isConstructor && !noAutogen) {
-				trace(field);
 				constructorInitFields.push("_order_id(generate_order_id())");
+
+				while(XComp.fieldNames.length > 0) {
+				    final name = XComp.fieldNames.pop();
+				    var curBody = body[body.length - 1];
+
+				    for(line in curBody.split(";")) {
+							var lineSeg = StringTools.replace(line, "\n", "");
+							if(StringTools.startsWith(lineSeg, "this->" + name + " = ")) {
+								final value = lineSeg.substring(("this->" + name + " = ").length, curBody.length - 1);
+
+								constructorInitFields.push(name + "(" + value + ")");
+								body[body.length - 1] = StringTools.replace(curBody, line + ";", "");
+							}
+					}
+				}
 			}
 
 			if(superConstructorCall != null) {

--- a/src/cxxcompiler/subcompilers/Expressions.hx
+++ b/src/cxxcompiler/subcompilers/Expressions.hx
@@ -46,6 +46,11 @@ using cxxcompiler.helpers.CppTypeHelper;
 @:access(cxxcompiler.subcompilers.Includes)
 @:access(cxxcompiler.subcompilers.Types)
 class Expressions extends SubCompiler {
+
+    // ----------------------------
+    // A map of all the names of the fields in the current class.
+    public var fieldNames(default, null): Array<String> = [];
+
 	// ----------------------------
 	// A public variable modified based on whether the
 	// current expression is being compiled for a header file.
@@ -1342,11 +1347,17 @@ class Expressions extends SubCompiler {
 
 			// @:nativeVariableCode
 			final nvc = Main.compileNativeVariableCodeMeta(accessExpr, result);
-			return if(nvc != null) {
+			final output = if(nvc != null) {
 				nvc;
 			} else {
 				result;
 			}
+
+			if(!fieldNames.contains(name) && StringTools.startsWith(result, "this->")) {
+		        fieldNames.push(name);
+			}
+
+			return output;
 		}
 	}
 


### PR DESCRIPTION
This will most likely fail a good portion of unit tests due to the change in how constructors are compiled now. I added constructor list support for the compiler because I came across a situation with my own learning project that would almost require the argument to be put in the constructor list since the class's property variable was immutable. Let me show an example. I do recommend doing some further tests of your own to see if there might be any issues.

This is the **Test.hx** I used:
```haxe
package;

class Test {
		public var lol:String;
		public var hah:String;

		@:const private var test:String;

		public function gyatt() {
			trace("gyatt");
		}

		public function new(hah:String) {
		    for (i in 0...hah.length) {
		        trace(i);
		    }

		    this.lol= "lol";
		       this.hah = hah;
			trace("Hello World");
			this.start();

			this.test = "test 2";
		}

		public function start() {
			trace("Starting...");
			trace("test: " + test);
		}
}
```

And here is how it would look before this PR:
```cpp
#include "Test.h"

#include <iostream>
#include <memory>
#include <string>
#include "_AnonStructs.h"
#include "haxe_Log.h"

using namespace std::string_literals;

Test::Test(std::string hah):
	_order_id(generate_order_id())
{
	int _g = 0;
	int _g1 = (int)(hah.size());

	while(_g < _g1) {
		int i = _g++;

		haxe::Log::trace(i, haxe::shared_anon<haxe::PosInfos>("Test"s, "Test.hx"s, 15, "new"s));
	};

	this->lol = "lol"s;
	this->hah = hah;
	std::cout << "Test.hx:20: Hello World"s << std::endl;
	this->start();
	this->test = "test 2"s;
}

void Test::gyatt() {
	std::cout << "Test.hx:10: gyatt"s << std::endl;
}

void Test::start() {
	std::cout << "Test.hx:27: Starting..."s << std::endl;
	haxe::Log::trace("test: "s + this->test, haxe::shared_anon<haxe::PosInfos>("Test"s, "Test.hx"s, 28, "start"s));
}
```
And I received an error since I'm trying to overload an immutable variable. However, I really just want to initialize my variable with my argument.
```
src/Test.cpp:27:13: error: no viable overloaded '='
   27 |         this->test = "test 2"s;
      |         ~~~~~~~~~~ ^ ~~~~~~~~~
/opt/homebrew/opt/llvm/bin/../include/c++/v1/string:1113:3: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char>'), but method is not marked const
 1113 |   operator=(const basic_string& __str);
      |   ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/string:1119:47: note: candidate template ignored: requirement '!__is_same_uncvref<std::string, std::string>::value' was not satisfied [with _Tp = basic_string<char>]
 1119 |   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(const _Tp& __t) {
      |                                               ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/string:1125:69: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char>'), but method is not marked const
 1125 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(basic_string&& __str)
      |                                                                     ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/string:1131:69: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char>'), but method is not marked const
 1131 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(initializer_list<value_type> __il) {
      |                                                                     ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/string:1135:69: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char>'), but method is not marked const
 1135 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(const value_type* __s) {
      |                                                                     ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/string:1141:85: note: candidate function not viable: 'this' argument has type 'const std::string' (aka 'const basic_string<char>'), but method is not marked const
 1141 |   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS basic_string& operator=(value_type __c);
      |                                                                                     ^
1 error generated.
```

Now with this PR, I can do exactly that without removing the `@:const` keyword:
```cpp
#include "Test.h"

#include <iostream>
#include <memory>
#include <string>
#include "_AnonStructs.h"
#include "haxe_Log.h"

using namespace std::string_literals;

Test::Test(std::string hah):
	_order_id(generate_order_id()), test("test 2"s), hah(hah), lol("lol"s)
{
	int _g = 0;
	int _g1 = (int)(hah.size());

	while(_g < _g1) {
		int i = _g++;

		haxe::Log::trace(i, haxe::shared_anon<haxe::PosInfos>("Test"s, "Test.hx"s, 15, "new"s));
	};
	std::cout << "Test.hx:20: Hello World"s << std::endl;
	this->start();
}

void Test::gyatt() {
	std::cout << "Test.hx:10: gyatt"s << std::endl;
}

void Test::start() {
	std::cout << "Test.hx:27: Starting..."s << std::endl;
	haxe::Log::trace("test: "s + this->test, haxe::shared_anon<haxe::PosInfos>("Test"s, "Test.hx"s, 28, "start"s));
}
```
There we go! It works!
```
Test.hx:15: 0
Test.hx:15: 1
Test.hx:15: 2
Test.hx:15: 3
Test.hx:15: 4
Test.hx:15: 5
Test.hx:15: 6
Test.hx:15: 7
Test.hx:15: 8
Test.hx:15: 9
Test.hx:15: 10
Test.hx:20: Hello World
Test.hx:27: Starting...
Test.hx:28: test: test 2
Main.hx:3: Hello World
```
