### PR TITLE
Have constructor list for more human like C++ code as well as more flexible immutable variables (Proper Implementation)

### DIFF
--- a/src/cxxcompiler/config/Meta.hx
+++ b/src/cxxcompiler/config/Meta.hx
@@ -592,8 +592,16 @@ enum abstract Meta(String) from String to String {
 	var IgnoreIfExtended = ":ignoreIfExtended";
 
 	/**
+		@:cppcList
+
+		If used on a constructor of a class, the constructor will be generate a
+		initializer list for the constructor.
+	**/
+        var CppcList = ":cppcList";
+
+	/**
 		Internal metadata. Cannot be used directly
-		
+
 		Used with @:passConstTypeParam to mark KExpr classes to be overwritten.
 	**/
 	var OverwriteKExpr = "-overwriteKExpr";

--- a/src/cxxcompiler/subcompilers/Classes.hx
+++ b/src/cxxcompiler/subcompilers/Classes.hx
@@ -19,6 +19,7 @@ import reflaxe.data.ClassFuncData;
 import reflaxe.data.ClassVarData;
 import reflaxe.debug.MeasurePerformance;
 import reflaxe.input.ClassHierarchyTracker;
+import reflaxe.helpers.ExprHelper;
 
 using reflaxe.helpers.ArrayHelper;
 using reflaxe.helpers.BaseTypeHelper;
@@ -1003,20 +1004,16 @@ class Classes extends SubCompiler {
 
 			// -----------------
 			// Get expression to compile
-			final bodyExpr = f.expr;
+			var bodyExpr = f.expr;
 
 			// To be added back, see TODO below...
 			// if(ctx.isConstructor) {
 			// 	XComp.startTrackingThisFields();
 			// }
 
-			XComp.pushTrackLines(useCallStack);
-			body.push(Main.compileClassFuncExpr(bodyExpr));
-			XComp.popTrackLines();
-
 			// -----------------
 			// Use initialization list to set _order_id in constructor.
-			final constructorInitFields = [];
+			final constructorInitFields:Array<String> = [];
 
 			if(ctx.isConstructor) {
 				if(!noAutogen) {
@@ -1024,32 +1021,65 @@ class Classes extends SubCompiler {
 				}
 
 				// -----------------
-				// Generate field initializations in constructor
-				//
-				// TODO:
-				// Don't use text processing here.
-				// Anaylze the `bodyExpr` TypedExpr above to get the class assignments.
-				// Then mark with a metadata like `@:reflaxeDontGenerate` and implement a-
-				// feature to ignore expressions with said metadata.
+				// Remove all assignments to `this->` fields in constructor body.
+				if(field.hasMeta(Meta.CppcList)) {
+						switch(bodyExpr.expr) {
+							case TBlock(exprs): {
+								var cleanExpressions:Array<haxe.macro.TypedExpr> = exprs.copy();
 
+								for(ex in exprs) {
+										// trace($type(ex));
+										switch(ex.expr) {
+											case TBinop(OpAssign, {expr: TField({expr: TConst(TThis)}, name)}, e2): {
+												switch(e2.expr) {
+													case TConst(_) | TLocal(_): {
+														cleanExpressions.remove(ex);
 
-				// Breaks too many tests, will add later...
-				// final thisFields = XComp.extractThisFields();
-				// while(thisFields.length > 0) {
-				// 	final name = thisFields.pop();
-				// 	var curBody = body[body.length - 1];
+														final name_raw = switch(name) {
+															case FInstance(_, _, s): s;
+															case _: null;
+														}
 
-				// 	for(line in curBody.split(";")) {
-				// 		var lineSeg = StringTools.replace(line, "\n", "");
-				// 		if(StringTools.startsWith(lineSeg, "this->" + name + " = ")) {
-				// 			final value = lineSeg.substring(("this->" + name + " = ").length, curBody.length - 1);
+														final value_raw = switch(e2.expr) {
+															case TConst(c): {
+																switch(c) {
+																	case TInt(v): Std.string(v);
+																	case TFloat(v): v;
+																	case TString(v): '"' + v + '"';
+																	case TBool(v): v ? "1" : "0";
+																	case TNull: "nullptr";
+																	case _: "0";
+																}
+															}
+															case TLocal(v): v.name;
+															case _: { throw "Impossible"; }
+														}
 
-				// 			constructorInitFields.push(name + "(" + value + ")");
-				// 			body[body.length - 1] = StringTools.replace(curBody, line + ";", "");
-				// 		}
-				// 	}
-				// }
+														constructorInitFields.push(name_raw + "(" + value_raw + ")");
+													}
+													case _: {}
+												}
+											}
+											case _: {
+												// trace(ex);
+											}
+										}
+								}
+
+								bodyExpr = {
+									expr: TBlock(cleanExpressions),
+									pos: bodyExpr.pos,
+									t: bodyExpr.t
+								};
+							}
+							case _: {}
+						}
+				}
 			}
+
+			XComp.pushTrackLines(useCallStack);
+			body.push(Main.compileClassFuncExpr(bodyExpr));
+			XComp.popTrackLines();
 
 			if(superConstructorCall != null) {
 				constructorInitFields.unshift(superConstructorCall);


### PR DESCRIPTION
This is a much nicer and more refined version of the previous implementation. I also made custom metadata called `@:cppcList,` which, when added to the constructor, handles constant and local variables in an initializer list.