### PR TITLE
add memalign function

### DIFF
--- a/src/cxx/Stdlib.hx
+++ b/src/cxx/Stdlib.hx
@@ -20,6 +20,10 @@ extern class Stdlib {
 	@:include("string", true)
 	public static extern function intToString(i: Int): String;
 
+	@:native("memalign")
+	@:include("stdlib.h", true)
+	public static extern function memalign(alignment: Int, size: Int): cxx.VoidPtr;
+
 	#if reflaxe_cpp_windows
 
 	@:native("getenv_s")


### PR DESCRIPTION
I have been experimenting with some things and they use the ``memalign`` function, as I see that in reflaxe.cpp this function is missing, I decided to make this pull request to add it, something simple xd